### PR TITLE
Assert statement used outside of tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ try:
         [sys.executable, "-m", "pip", "show", "pkg_utils"],
         check=True, capture_output=True)
     match = re.search(r'\nVersion: (.*?)\n', result.stdout.decode(), re.DOTALL)
-    assert match and tuple(match.group(1).split('.')) >= ('0', '0', '5')
+    if not (match and tuple(match.group(1).split('.')) >= ('0', '0', '5')):
+        raise AssertionError
 except (subprocess.CalledProcessError, AssertionError):
     subprocess.run(
         [sys.executable, "-m", "pip", "install", "-U", "pkg_utils"],


### PR DESCRIPTION
Using assert statement in application logic is discouraged. Assert is usually removed with compiling to optimized byte code (python -o producing *.pyo files). It would be better to raise an exception instead.